### PR TITLE
Do not play a starting chime when running a quiet query

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -99,6 +99,7 @@ This empty configuration will even work if you use;
     verbose:false, // You can get error or some logs when this value is set as true.
 
     startChime: "connection.mp3", // you can use `mp3` to play chime when your mic is ready. It should be playable with your `play.playProgram`
+    noChimeOnSay: false, // When using the `ASSISTANT_SAY` trigger, you can prevent the chime from being played before your words
 
     auth: { // I believe you don't need to change this.
       keyFilePath: "./credentials.json"

--- a/MMM-AssistantMk2.js
+++ b/MMM-AssistantMk2.js
@@ -8,6 +8,7 @@ Module.register("MMM-AssistantMk2", {
     projectId: "", // Google Assistant ProjectId (Required only when you use gAction.)
     useGactionCLI: false,
     startChime: "connection.mp3",
+    noChimeOnSay: false,
     deviceModelId: "", // It should be described in your config.json
     deviceInstanceId: "", // It should be described in your config.json
     deviceLocation: { // (optional)
@@ -321,7 +322,7 @@ Module.register("MMM-AssistantMk2", {
           sender = sender.name
         }
         this.currentProfile = this.config.profiles[this.config.defaultProfile]
-        this.assistant.activate(this.currentProfile, payload, sender)
+        this.assistant.activate(this.currentProfile, payload, sender, true /* sayMode */)
         break
     }
   },
@@ -559,7 +560,7 @@ class AssistantHelper {
     }, 3000)
   }
 
-  activate(profile, textQuery=null, sender=null, id=null) {
+  activate(profile, textQuery=null, sender=null, id=null, sayMode=false) {
     if (this.youtubePlaying && this.config.pauseOnYoutube) {
       this.log("Assistant will not work during Youtube playing.")
       return false
@@ -569,7 +570,7 @@ class AssistantHelper {
       //this.deactivate()
       this.changeStatus("READY")
       this.sendNotification(this.config.notifications.ASSISTANT_ACTIVATED)
-      this.sendSocketNotification("START", {profile:profile, textQuery:textQuery, sender:sender, id:id})
+      this.sendSocketNotification("START", {profile:profile, textQuery:textQuery, sender:sender, id:id, sayMode:sayMode})
       if (this.config.onActivate) {
         setTimeout(()=>{
           this.doCommand(this.config.onActivate, "onActivate")

--- a/USAGE.md
+++ b/USAGE.md
@@ -255,6 +255,7 @@ If Youtube video is not played :
     - NOTICE:
       - This feature is somekind of Assistant hooking. If you say "Repeat after me SOMETHING", Google Assistant will repeat SOMETHING. So, there could be a possibility of not responding as intend. Too long or complex text might be not available.
       - Currently I can't find correspondence of `Repeat after me` for **German/Japanese/Korean** language. PR please.
+      - You can prevent the starting chime from being played before your own text is pronounced: set the config variable `noChimeOnSay` to `true`.
     - Thanks to [Valerio Pilo](https://github.com/vpilo). His brilliant idea and PR could make this feature.
 
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -122,12 +122,18 @@ module.exports = NodeHelper.create({
     if (this.continueConversation) {
       payload = this.currentPayload
     }
-    this.playChime(()=>{
+
+    var cb = ()=>{
       if (textQuery) {
         this.sendSocketNotification("TRANSCRIPTION", {done:true, transcription:textQuery})
       }
       this.activate(payload, textQuery, sender)
-    })
+    };
+    if (pObj.sayMode == true && this.config.noChimeOnSay) {
+      cb()
+    } else {
+      this.playChime(cb)
+    }
   },
 
   activate: function(payload, textQuery=null, sender=null) {


### PR DESCRIPTION
The starting chime was getting quite annoying when running `ASSISTANT_SAY` queries often.
This gets rid of it.

I am only 99% sure it is a good idea: random speech coming 'unannounced' from the mirror could be... creepy. Specially in combination with remote triggers like Telegram.

Thoughts?